### PR TITLE
bug: fix mobile footer issues

### DIFF
--- a/src/components/Email-Form.astro
+++ b/src/components/Email-Form.astro
@@ -74,7 +74,7 @@
 
   @media (max-width: 825px) {
     .emailform {
-      position: absolute;
+      position: relative;
     }
   }
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,4 +22,11 @@
         margin: 0;
         flex: 1;
     }
+
+    /* media query to make footer vertical on mobile */
+    @media (max-width: 600px) {
+        .footer {
+            flex-direction: column;
+        }
+    }
 </style>


### PR DESCRIPTION
# bug: fix mobile footer issues
## Description:
The footer was acting weird on mobile, so I switched the flex layout to column with a breakpoint and set relative positioning on the email form component to stop overlap.

## Related Issue:
![image](https://github.com/thepurplebubble/site/assets/92754843/d09c19cd-d25c-4ec3-89be-745b6554d261)
