### PR TITLE
changed font of form

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -169,4 +169,10 @@ if (Astro.request.method === "POST") {
   input[type="checkbox"] {
     margin-right: 0.5rem;
   }
+  input::placeholder {
+    font-family: "Averia Serif Libre", serif;
+  }
+  label {
+    font-family: "Averia Serif Libre", serif;
+  }
 </style>


### PR DESCRIPTION
magick.css was causing the font clash of the form to the webpage, this change overrides the font set by the css framework

# Pull Request

I cannot see contributing guidelines file as of now, but to my knowledge everything is as intended.

## Description:

Changed font of the form in the index page to be the same as the rest of the page and not clash with the rest of the page

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #53 
