### PR TITLE
Updated placeholder styling to desired size

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -171,6 +171,7 @@ if (Astro.request.method === "POST") {
   }
   input::placeholder {
     font-family: "Averia Serif Libre", serif;
+    font-size: 2rem;
   }
   label {
     font-family: "Averia Serif Libre", serif;


### PR DESCRIPTION
Placeholder styling has been set to desired size (2rem)

# Pull Request

I updated placeholder styling to desired size

## Description:

This change makes the placeholder text in the form 2rem as requested.

## Related Issue:

This closes "Make the form text smaller"

Closes #59
